### PR TITLE
Possible Makefile linux compatibility issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROGRAM_NAME = scythe
 VERSION = 0.981
 CC = gcc
-CFLAGS = -Wall -pedantic -DVERSION=$(VERSION) -std=gnu99
+CFLAGS = -Wall -pedantic -DVERSION=$(VERSION) -std=gnu99 
 DEBUG = -g
 OPT = -O3
 ARCHIVE = $(PROGRAM_NAME)_$(VERSION)
@@ -27,7 +27,7 @@ valgrind: build
 	valgrind --leak-check=full --show-reachable=yes ./scythe -a solexa_adapters.fa test.fastq
 
 test: match.o util.o prob.o tests.o
-	$(CC) $(CFLAGS) $(LDFLAGS) $? -o tests && ./tests
+	$(CC) $(CFLAGS) $? $(LDFLAGS) -o tests && ./tests
 
 testclean:
 	rm -rf ./tests
@@ -42,7 +42,7 @@ dist:
 	tar -zcf $(ARCHIVE).tar.gz src Makefile
 
 build: match.o scythe.o util.o prob.o 
-	$(CC) $(CFLAGS) $(LDFLAGS) $? -o scythe
+	$(CC) $(CFLAGS) $? $(LDFLAGS) -o scythe
 
 debug:
-	$(CC) $(LDFLAGS) $(DEBUG) -o scythe src/*.c
+	$(CC) $(DEBUG) $(LDFLAGS) -o scythe src/*.c


### PR DESCRIPTION
I was getting these linking errors on a fresh checkout of the repo

gcc -Wall -pedantic -DVERSION=0.981 -std=gnu99 -lz -lm match.o scythe.o util.o prob.o -o scythe
scythe.o: In function `ks_getc':
scythe.c:(.text+0x18a): undefined reference to`gzread'
scythe.o: In function `ks_getuntil':
scythe.c:(.text+0x289): undefined reference to`gzread'
scythe.o: In function `main':
scythe.c:(.text+0xc4b): undefined reference to`gzopen'
scythe.c:(.text+0x1024): undefined reference to `gzclose'
scythe.c:(.text+0x1044): undefined reference to`gzopen'
scythe.c:(.text+0x151a): undefined reference to `gzclose'
util.o: In function`ks_getc':
util.c:(.text+0x18a): undefined reference to `gzread'
util.o: In function`ks_getuntil':
util.c:(.text+0x289): undefined reference to `gzread'
prob.o: In function`qual_to_probs':
prob.c:(.text+0x129): undefined reference to `powf'
prob.c:(.text+0x1a8): undefined reference to`powf'
collect2: ld returned 1 exit status
make: **\* [build] Error 1

Comments in this thread led me to this solution: moving the $(LDFLAGS) after the
sources ensures some linux compatibility

http://stackoverflow.com/questions/9145177/undefined-reference-to-gzopen-error
