### PR TITLE
Call fclose on output_fp when -o option is given

### DIFF
--- a/src/scythe.c
+++ b/src/scythe.c
@@ -258,6 +258,8 @@ int main(int argc, char *argv[]) {
 
   kseq_destroy(seq);
   destroy_adapters(aa, MAX_ADAPTERS);
+  if (output_fp != stdout && output_fp != NULL)
+      fclose(output_fp);
   gzclose(fp);
   return 0;
 }


### PR DESCRIPTION
Hi Vince,

Tiny pedantic change picked up when `valgrind`ing the last PR. Basically, this should call `fclose` on the file opened when a file is opened w/ `fopen` as a result of the `-o` command line flag.

Cheers,
Kevin
