### PR TITLE
Keep makefile & readme versions in sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROGRAM_NAME = scythe
-VERSION = 0.991
+VERSION = 0.993
 CC = gcc
 DEBUG ?= 0
 CFLAGS = -Wall -pedantic -DVERSION=$(VERSION) -std=gnu99


### PR DESCRIPTION
Managed to confuse myself this morning trying to work out which version of `scythe` I had installed. This tiny fix bumps version in the makefile so that `scythe --version` shows the same version as is shown in the readme. 

Cheers,
K
